### PR TITLE
refactor: store userLocation as object with latitude and longitude keys

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -3,7 +3,7 @@ import { getPositionForAR, getRelativePosition } from '../src/modules/utils';
 describe('getRelativePosition', () => {
   it('returns relative position for given user location and target', () => {
     const testTargetCoords = { latitude: 53.8, longitude: -1.55 };
-    const testUserCoords = { coords: { latitude: 53.797, longitude: -1.557 } };
+    const testUserCoords = { latitude: 53.797, longitude: -1.557 };
 
     const relativePosition = getRelativePosition(
       testUserCoords,
@@ -17,7 +17,7 @@ describe('getRelativePosition', () => {
 
 describe('getPositionForAR', () => {
   it('returns transformed coordinates', () => {
-    const testUserCoords = { coords: { latitude: 53.797, longitude: -1.557 } };
+    const testUserCoords = { latitude: 53.797, longitude: -1.557 };
     const testTargetCoords = { latitude: 53.8, longitude: -1.55 };
     const testCompassHeading = 45;
 

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -6,7 +6,6 @@ import {
   ViroTrackingReason,
   ViroTrackingStateConstants,
 } from '@viro-community/react-viro';
-import testData from '../../test-data.json';
 import PointMarker from './PointMarker';
 import CompassHeading from 'react-native-compass-heading';
 import { getNearbyPOIs } from '../modules/apis';
@@ -26,7 +25,10 @@ const HomeScreenSceneAR = ({
     };
   };
 }) => {
-  const [userLocation, setUserLocation] = useState<GeoPosition | null>(null);
+  const [userLocation, setUserLocation] = useState<{
+    latitude: number;
+    longitude: number;
+  } | null>(null);
   const [pointsOfInterest, setPointsOfInterest] = useState<
     {
       latitude: number;
@@ -76,7 +78,10 @@ const HomeScreenSceneAR = ({
       if (isGranted) {
         Geolocation.getCurrentPosition(
           (position) => {
-            setUserLocation(position);
+            setUserLocation({
+              latitude: position.coords.latitude,
+              longitude: position.coords.longitude,
+            });
             onLocationReceived(position);
           },
           (err) => {

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,26 +1,23 @@
-import { GeoPosition } from 'react-native-geolocation-service';
-
 const DEGREES_TO_RADIANS_CONVERSION = (2 * Math.PI) / 360;
 
 export function getRelativePosition(
-  userLocation: GeoPosition,
-  target: {
+  userLocation: { latitude: number; longitude: number },
+  targetLocation: {
     latitude: number;
     longitude: number;
-    [key: string]: any;
   },
 ): { x: number; z: number } {
   const RADIUS_OF_EARTH_IN_METRES = 6_371_000;
 
-  const relativeLatitude = userLocation.coords.latitude - target.latitude;
+  const relativeLatitude = userLocation.latitude - targetLocation.latitude;
   const relativeZ =
     relativeLatitude *
     DEGREES_TO_RADIANS_CONVERSION *
     RADIUS_OF_EARTH_IN_METRES;
 
-  const relativeLongitude = target.longitude - userLocation.coords.longitude;
+  const relativeLongitude = targetLocation.longitude - userLocation.longitude;
   const latitudeScaleFactor = Math.cos(
-    userLocation.coords.latitude * DEGREES_TO_RADIANS_CONVERSION,
+    userLocation.latitude * DEGREES_TO_RADIANS_CONVERSION,
   );
   const relativeX =
     relativeLongitude *
@@ -32,15 +29,15 @@ export function getRelativePosition(
 }
 
 export function getPositionForAR(
-  userLocation: GeoPosition | null,
-  target: { latitude: number; longitude: number; [key: string]: any },
+  userLocation: { latitude: number; longitude: number } | null,
+  targetLocation: { latitude: number; longitude: number },
   compassHeading: number,
 ): [x: number, y: number, z: number] {
   if (!userLocation) {
     throw new Error('user location not found');
   }
 
-  const relativePosition = getRelativePosition(userLocation, target);
+  const relativePosition = getRelativePosition(userLocation, targetLocation);
   const headingInRadians = compassHeading * DEGREES_TO_RADIANS_CONVERSION;
 
   return [


### PR DESCRIPTION
Previously userLocation was type GeoPosition which made it hard to work with. Storing it in this way makes it easier to work with. Refactor getPositionForAR util function to work with new userLocation. Update util unit tests.