### PR TITLE
chore: add jsx to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "@react-native/typescript-config/tsconfig.json",
-  "compilerOptions": { "typeRoots": ["./types"] }
+  "compilerOptions": { "typeRoots": ["./types"] },
+  "jsx": "react-jsx"
 }


### PR DESCRIPTION
Resolves "Cannot use JSX unless the ‘ — jsx’ flag is provided" errors